### PR TITLE
Little update of links

### DIFF
--- a/app/components/footer.jsx
+++ b/app/components/footer.jsx
@@ -33,7 +33,6 @@ export default class ZFooter extends React.Component {
           </Col>
           <Col md="4">
             <a href="https://myhush.org/">website</a><br/>
-            <a href="https://forum.myhush.org/">forum</a><br/>
             <a href="http://dashboard.myhush.org/">dashboard</a><br/>
             <a href="https://github.com/MyHush/myhushwallet">github</a><br/>
             <a href="http://myhush.org/discord">discord</a><br/>

--- a/app/components/footer.jsx
+++ b/app/components/footer.jsx
@@ -35,7 +35,7 @@ export default class ZFooter extends React.Component {
             <a href="https://myhush.org/">website</a><br/>
             <a href="http://dashboard.myhush.org/">dashboard</a><br/>
             <a href="https://github.com/MyHush/myhushwallet">github</a><br/>
-            <a href="http://myhush.org/discord">discord</a><br/>
+            <a href="http://myhush.org/discord/">discord</a><br/>
           </Col>
         </Row>
         </Container>


### PR DESCRIPTION
**Deleting a link to 'forum.myhush.org'**
-The 'forum.myhush.org' website no longer exists.

**Modification of the link to the Discord**
-The link 'http://myhush.org/discord' automatically links to 'http://myhush.org/discord/' and automatically sends the user back to the HUSH Discord. The removal of a step / redirection allows to shorten the redirection time, the link has been modified.